### PR TITLE
Added missing reference in resources list

### DIFF
--- a/tekton-install/kustomization.yaml
+++ b/tekton-install/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - resources/dashboard-ingress.yaml
 - resources/dashboard-extensions-base.yaml
 - resources/dashboard-extensions-cronjobs.yaml
+- resources/dashboard-extensions-jobs.yaml
 - resources/psps.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
I forgot to include the new file in the list of resources that Kustomize should install.