### PR TITLE
Added triggers and related resources for PR triggers from GitHub webhook

### DIFF
--- a/tekton-resources/triggers/cluster-trigger-bindings.yaml
+++ b/tekton-resources/triggers/cluster-trigger-bindings.yaml
@@ -1,0 +1,35 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: ClusterTriggerBinding
+metadata:
+  name: github-pr
+  labels:
+    app: tekton-resources
+    app.kubernetes.io/name: tekton-resources
+    app.kubernetes.io/instance: github-pr
+    app.kubernetes.io/part-of: tekton-triggers
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: github, pull request
+spec:
+  params:
+    - name: URL
+      value: $(body.pull_request.url)
+    - name: NUMBER
+      value: $(body.number)
+    - name: TITLE
+      value: $(body.pull_request.title)
+    - name: BODY
+      value: $(body.pull_request.body)
+    - name: GIT_REVISION
+      value: $(body.pull_request.head.sha)
+    - name: CLONE_URL
+      value: $(body.repository.clone_url)
+    - name: REPO_NAME
+      value: $(body.repository.name)
+    - name: REPO_ORG
+      value: $(body.repository.owner.login)
+    - name: CHANGED_FILES
+      value: $(extensions.changed_files)
+    - name: MERGEABLE_STATE
+      value: $(body.pull_request.mergeable_state)
+---

--- a/tekton-resources/triggers/github-automatic-pr/event-listener.yaml
+++ b/tekton-resources/triggers/github-automatic-pr/event-listener.yaml
@@ -1,0 +1,41 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: github-automatic-pr
+  labels:
+    app: tekton-resources
+    app.kubernetes.io/name: tekton-resources
+    app.kubernetes.io/component: trigger-event-listener
+    app.kubernetes.io/instance: github-automatic-pr
+    app.kubernetes.io/part-of: tekton-triggers
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: github, pull request
+spec:
+  triggers:
+    - name: github-automatic-pr
+      interceptors:
+        - ref:
+            name: "github"
+          params:
+            - name: "eventTypes"
+              value: ["pull_request"]
+            - name: "addChangedFiles"
+              value:
+                enabled: true
+            - name: "secretRef"
+              value:
+                secretName: github-webhook-secret
+                secretKey: token
+        - ref:
+            name: cel
+          params:
+          - name: filter
+            value: "body.action in ['opened', 'synchronize', 'reopened']"
+      bindings:
+        - ref: github-pr
+          kind: ClusterTriggerBinding
+      template:
+        ref: github-automatic-pr
+
+---

--- a/tekton-resources/triggers/github-automatic-pr/ingress.yaml
+++ b/tekton-resources/triggers/github-automatic-pr/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tekton-el-github-automatic-pr
+  labels:
+    app: tekton-resources
+    app.kubernetes.io/name: tekton-resources
+    app.kubernetes.io/component: trigger-event-listener
+    app.kubernetes.io/instance: github-automatic-pr
+    app.kubernetes.io/part-of: tekton-triggers
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: github-pr-webhook.ei9o7.k8s.gorilla.eu-central-1.aws.gigantic.io
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: el-github-automatic-pr
+                port:
+              name: http-listener
+  tls:
+    - hosts:
+        - github-pr-webhook.ei9o7.k8s.gorilla.eu-central-1.aws.gigantic.io
+      secretName: tekton-el-github-automatic-pr
+---

--- a/tekton-resources/triggers/github-automatic-pr/trigger-template.yaml
+++ b/tekton-resources/triggers/github-automatic-pr/trigger-template.yaml
@@ -1,0 +1,32 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: github-automatic-pr
+  labels:
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: github, pull request
+spec:
+  params:
+  - name: URL
+  - name: NUMBER
+  - name: TITLE
+  - name: BODY
+  - name: GIT_REVISION
+  - name: CLONE_URL
+  - name: REPO_NAME
+  - name: REPO_ORG
+  - name: CHANGED_FILES
+  - name: MERGEABLE_STATE
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: github-automatic-pr-filter-
+      spec:
+        taskSpec:
+          steps:
+            - image: ubuntu
+              script: |
+                #! /bin/bash
+                # TODO: Filter out PRs based on ones we should handle and trigger the appropriate pipelines

--- a/tekton-resources/triggers/secrets.yaml
+++ b/tekton-resources/triggers/secrets.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: github-webhook-secret
+    labels:
+        application.giantswarm.io/team: team-tinkerers
+type: Opaque
+data:
+    token: ENC[AES256_GCM,data:56n7CA8wveCndFRLNACb21nt/+VMm5ziTWSv9L1g2YFVz0H7GjZ6hA==,iv:+MQWhC7//fRBNlB161PZr/a5uz/hM/e9K3zwnI6gba4=,tag:S56eaqr89QtjYCMEacD8QA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age12vs3x7x0ne8ghx4js9dwetn29vvtrrelvcgup2reqmdhdeqwd9hqht25ex
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdlRhbU9Sdzc3dzhybFUy
+            L1U4VjF2dUx2elYvWXBpR3RWSW4yZDVxYkhvCkdiNzhLSkx4R0RWck1VMWxTOTJS
+            QkYwVFV6dThXZGx5RDFrR2srRk9iVGsKLS0tIFVJQU9GYWx4cTZ0eWRBYk4waDcx
+            V1dickQrSWFuUE5DL1hraGNpWHdjLzAK6NFm5G/1dS6iS6xk7wPAEfKCXGPrGIyR
+            MbTQVhkMp67VeCXRXiQvCOVuwDqZ1FfYIlD/rIv7pY7+eGrHmavtog==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2023-02-02T12:12:56Z"
+    mac: ENC[AES256_GCM,data:DR9mPPtDx/iAgzx8b7Ob4AJ50cXwzHdqGrAQ0IuYdHbAYsIt+49uAtC/VGavdFIEiV4t0VU5MOEasqTSzo/H7iIBacl3m9mxiHIuy8aaNeJJPmXrTxcv+hSx9cZSSarWGXrroB3wBU7TQb5MUX/q7LEGa5qc8se3xbUnUE7aezE=,iv:KVS+7bkmZkfskUzdRg7/Xw8DbjMZEra1/1QyhWNXOQ4=,tag:tbFzdtqNBdJMY/9auULWTw==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3


### PR DESCRIPTION
I've added:
* a cluster-wide trigger binding for GitHub PRs
* a secret to use when configuring our GitHub webhooks
* a trigger, template, eventlistener and ingress for "automatic" triggers from PRs (e.g. when opened, sync'd, reopened)