### PR TITLE
Handle null (empty) body in PR payload

### DIFF
--- a/tekton-resources/triggers/event-listener.yaml
+++ b/tekton-resources/triggers/event-listener.yaml
@@ -58,7 +58,7 @@ spec:
           - name: filter
             value: "body.action in ['created', 'edited']"
           - name: filter
-            value: "body.comment.body.substring('/run')"
+            value: "body.comment.body != null && body.comment.body.substring('/run')"
       bindings:
         - ref: github-pr
           kind: ClusterTriggerBinding
@@ -85,7 +85,7 @@ spec:
           - name: filter
             value: "body.action in ['opened']"
           - name: filter
-            value: "body.pull_request.body.substring('/run')"
+            value: "body.pull_request.body != null && body.pull_request.body.substring('/run')"
       bindings:
         - ref: github-pr
           kind: ClusterTriggerBinding
@@ -113,9 +113,9 @@ spec:
           - name: filter
             value: "body.action in ['edited']"
           - name: filter
-            value: "body.pull_request.body.substring('/run')"
+            value: "body.pull_request.body != null && body.pull_request.body.substring('/run')"
           - name: filter
-            value: "has(body.changes) && has(body.changes.body) && body.changes.body.from.substring('/run') < 0"
+            value: "has(body.changes) && has(body.changes.body) && body.changes.body.from != null && body.changes.body.from.substring('/run') < 0"
       bindings:
         - ref: github-pr
           kind: ClusterTriggerBinding
@@ -123,7 +123,7 @@ spec:
         - name: COMMENT
           value: $(body.pull_request.body)
         - name: PREVIOUS_COMMENT
-          value: $(has(body.changes) && has(body.changes.body) && body.changes.body.from.)
+          value: $(body.changes.body.from)
       template:
         ref: github-pr-comment
 ---


### PR DESCRIPTION
Turns out that creating a PR without a description results in the `body` property being `null` rather than an empty string.