### PR TITLE
Disable changed_files until next version of Tekton Triggers

### DIFF
--- a/tekton-resources/triggers/cluster-trigger-bindings.yaml
+++ b/tekton-resources/triggers/cluster-trigger-bindings.yaml
@@ -28,8 +28,8 @@ spec:
       value: $(body.repository.name)
     - name: REPO_ORG
       value: $(body.repository.owner.login)
-    - name: CHANGED_FILES
-      value: $(extensions.changed_files)
+    # - name: CHANGED_FILES
+    #   value: $(extensions.changed_files)
     - name: MERGEABLE_STATE
       value: $(body.pull_request.mergeable_state)
 ---

--- a/tekton-resources/triggers/github-automatic-pr-triggertemplate.yaml
+++ b/tekton-resources/triggers/github-automatic-pr-triggertemplate.yaml
@@ -17,6 +17,7 @@ spec:
   - name: REPO_NAME
   - name: REPO_ORG
   - name: CHANGED_FILES
+    default: ""
   - name: MERGEABLE_STATE
   resourcetemplates:
     - apiVersion: tekton.dev/v1beta1

--- a/tekton-resources/triggers/github-pr-comment-triggertemplate.yaml
+++ b/tekton-resources/triggers/github-pr-comment-triggertemplate.yaml
@@ -21,6 +21,7 @@ spec:
   - name: REPO_NAME
   - name: REPO_ORG
   - name: CHANGED_FILES
+    default: ""
   - name: MERGEABLE_STATE
   - name: COMMENT
   - name: PREVIOUS_COMMENT


### PR DESCRIPTION
The `changed_files` extension isn't actually released yet so need to disable it until the next release of Tekton Triggers.