### PR TITLE
Handle different payload with issue_comment on PR

### DIFF
--- a/tekton-resources/triggers/cluster-trigger-bindings.yaml
+++ b/tekton-resources/triggers/cluster-trigger-bindings.yaml
@@ -30,8 +30,39 @@ spec:
       value: $(body.repository.owner.login)
     # - name: CHANGED_FILES
     #   value: $(extensions.changed_files)
-    - name: MERGEABLE_STATE
-      value: $(body.pull_request.mergeable_state)
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: ClusterTriggerBinding
+metadata:
+  name: github-pr-issue
+  labels:
+    app: tekton-resources
+    app.kubernetes.io/name: tekton-resources
+    app.kubernetes.io/instance: github-pr-issue
+    app.kubernetes.io/part-of: tekton-triggers
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: github, pull request
+spec:
+  params:
+    - name: URL
+      value: $(body.issue.pull_request.url)
+    - name: NUMBER
+      value: $(body.issue.number)
+    - name: TITLE
+      value: $(body.issue.title)
+    - name: BODY
+      value: $(body.issue.body)
+    - name: GIT_REVISION
+      value: ""
+    - name: CLONE_URL
+      value: $(body.repository.clone_url)
+    - name: REPO_NAME
+      value: $(body.repository.name)
+    - name: REPO_ORG
+      value: $(body.repository.owner.login)
+    # - name: CHANGED_FILES
+    #   value: $(extensions.changed_files)
 ---
 
 apiVersion: triggers.tekton.dev/v1beta1

--- a/tekton-resources/triggers/event-listener.yaml
+++ b/tekton-resources/triggers/event-listener.yaml
@@ -69,7 +69,7 @@ spec:
           - name: filter
             value: "body.comment.body != null && body.comment.body.indexOf('/run') >= 0"
       bindings:
-        - ref: github-pr
+        - ref: github-pr-issue
           kind: ClusterTriggerBinding
         - ref: github-comment
           kind: ClusterTriggerBinding

--- a/tekton-resources/triggers/github-pr-comment-triggertemplate.yaml
+++ b/tekton-resources/triggers/github-pr-comment-triggertemplate.yaml
@@ -73,3 +73,9 @@ spec:
           steps:
             - name: filter-to-pipelines
               image: quay.io/giantswarm/pr-comment-filter:latest
+              env:
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                      name: tinkerers-ci-github-token
+                      key: GITHUB_TOKEN


### PR DESCRIPTION
When commenting on a PR the payload from GitHub is actually an `issue_comment` payload that contains an `issue` property rather than a `pull_request` property. This payload contains less details about the PR (such as not including the HEAD and BASE details) which will need to be fetched by the task.