### PR TITLE
Added shared tasks for use when testing CAPI WCs

### DIFF
--- a/tekton-resources/pipelines/create-capg-cluster.yaml
+++ b/tekton-resources/pipelines/create-capg-cluster.yaml
@@ -1,0 +1,310 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: create-capg-cluster
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: create-capg-cluster
+secrets:
+- name: regcred
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mc-kubeconfig-gohan
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: create-capg-cluster
+type: Opaque
+data:
+  kubeconfig: ENC[AES256_GCM,data:78gXLlENjTBLo7ChUYD6FM2fw5anyZLm7hKpOqvOS+D0qkbeYVGw7T5wNEEyTf5XM3ynygKJdt7NgR1aCRS3x6KKWsc/YRbyESSLdEyPh6xQ4mgCE6mqis651uRNFJJB+mbZpT/7hpZaBCfBt3cpVrdRN4rCHntk7x4EwLSN7LIErJIM+p1OWF+soLdrXXZWbp56Gsax7jA5sDJ91YYM3vEpbFrfHPPJGgq0JzXtW+k5Bo/Am4QK6iL8i7gfT07vrhGt8eOqxeTxxYcF0imn6Y7dyiXbYXOjjF4ZE+BcXuYdaAaObAqmTIKcVkJySsthth/6YtEDsxqDTYSvE9c/5zwjMezhF0hEclQLEUY+7AZBbFJLpEQojFu0PpvhrJcl2TMZq470AqvpAD2h8bvdt/ND8UBb/JqcxSpk+748TKB+iiI9bOxZ8gCNoomrASz593N1IDlwN/EGVTUhJddreIePFNphgODmiDnQmyzPcC5Lb/cS1h/qD8Ru2wJ5cjuY0rEzzGxtqjDAkX+PWE73fxFVRlqpz47wl/5DK58Emvw+Q/TdSodm2hCmmt9ELES2XxQgl8PReQamCEdO1kC57C7mPAuQ4h48IQyElsFfEsZ7WiBzexB6ZrqXHOcKb3DfozoZBVtlRrLhd4Ky0j/gylp38NvSNcmD46vesa3YKWMnfpQxvUXOn5nFINroBLLvEnAxjvJULt9aVp61/zMgf3P5QSfaz9y+ASMdirw8dXdxibmDf6mJdz3JPrHDRLq2oJEmt8VMAc4dYbTW046tEzX2wuqaS5uxJM4x36SMgBKqvAcsmQTWJlbWAqOcudZ8luPogOeQja/BMJuztmvOM1gwncbzkjym3PZfUgu+Pf74XXJbhnhan05Q28uEdKhRiH/UAKr9PY0fNjMQpmXtJEGcUXVcHJmC8cGqbC+E2DGp+Y19DXrSLRmYZJA7Ava/AqNvNz/tQJLwhLMRzS2cvwRMCKm6Agng4IGJ/kjShFXdddHYs9/tTCPcM9JTtJXi3Z+D0JJkwWRQHnZTDeh83DYGQII1fLXQp9cy6apsoluen1IVGjtEDE0UgODcgGBEKZyVlg1mUOhyJ84GjXhGYqurJxfMGr2NlLdJO7ieijvH5CqD/uMyL0Tp5otg8SQK5cwMoCTe8K4JM29QRGShybthoxkAXlLc3xkg8ANo41iEfbrzQ3VvrWBI1EvYJg7NbSM5qjWxdv6/uWKDMIyLbhf+0ye7tw55tpESkqGcMpNxn4rA9se2KKXeMDxtCrtQpaH8Ey8RpjPmhQ4XaDEzslMnq/XgXpcinRO8hCTFUyE9RAXbdLWzqZax3xizBXPoR+XYHUz8X0pziRwsCUX1KdoaHPxzlVhzVxiNM5Ac1mdjQEHuIacSjs3Zm8Q8zqkLtRM1z9mgVKPAZN+EP/jgIw0IrZ0bHN2Ohj4HGyX6XxPnFvViF5MvljCVBkeXpiwfn0uPEh/3euTuBsrR72bUq5HvZFNEaukj0JEwiKxdqdEptLuGup0BWOjn4P0hq7vi9CdhL+XZz1FSMA3y6klHkfkcjYD0yx8vKXJ9oPTKxY3ymrc7n5qeXt/9TyV4rXZ1+ROCXHp/R50x0HIgOqbFjdZAdHDNw1ydZ1tf7pBnZmt2Hj1cxpu8NaX5yYXTa/xXCmUkyR3PUKvCQZaC8ByB90H9k+yAxNuZKoIEBoK8aOaWC901fQB1nKzx8Ddq2zSOQuqeSofPL79TI1pY2LED/mainjHhA2gjnL6KSbb3YMpWiRh23Zk1O0fiXkMIHB/w7oUfwbVXowNn4VHXBy0qFaaE+nd7wJK0IrXCjx4C1YiPZnK7Sd6ERTGMrR6ZT4a/lYT8v+1alQwZL4+PMj3ddqyx6B319F4lCAHwJzCh/mubw6hmQN6otit/6XJGr+HF8X7hDqYU7YwmG/5Z/LbmRvle2uDEscS+RJrYFoc0pMQ6NkxaeSB7/uYqku0RF3Ev2iCSA1YptlYPMkimXg1ma3lgui0HD8rqiI5FemWiydLxmRgdtE/s6VaHv1cpzGK2AyBMY3c/+cwJd1NL0T1d/5t+wsMa2lIRV4Rc35YMTfaCr3JIz1XvCxbtAZR4bQndUEN2gnaA4T7YhmynaTIhO/CFcFUoKgQS/qGvwSwx6d62KgFcWt1uCoBwg9ZDKXLpQyDQqwY5kgu66WbLPlKBXTkg2oZwn2pI4R+ojc1HF351lfLrFLVg9S1jp2pPBI7JKsMJCiveoZBCKtZdeuX0thgdpPHII5VZw8pUrLifS8eZgfx6xKVbhseyPu9JlR3DULmisPvCadtubCefqe2KNnQYpcRqmJKu5A8qFxCKrvTO4tR9glPZ1clQ/iLyMAfv+DHeaL8z5Fe6QQFvZG1P0ggDw3e/iVhVQgKxFp3bZdpv42bOLOhSiHmIXRqGJm4CKYb2J0GgbOd46S9+liEXhD2A2AVafiK4V1N4aeg0Ays+hHGs0n/lVXi8+Z6W3PeKqsDU0mbKMQ4KQFz6rGBGctNdn6JfooQNCN7uKss+FGMFDunpckjoZ2tvEFejxeneLYOKwxCyVcysJuhtrrJu6C4C21Qdoe21IwME8+qaNqov/FO5gn9sDvhdDC7aptdxNAZF74Nf7s712W120YSFjTpKbcy7ftpYwH+/LmjMFbSeQwpqJSY3g4TCzXZ9JHIUX9duT/KGTRA0t7eGwvCRznh9NokQPxGL2NaMnKvn3WPws/9gWhGQ6yy57cZVkXr53ijT4oLHaJy5EUfbdLFf17xxoFD4pGCxT4iHO28gBb1kEqSt0/tdwPkDFeLe2ye+W8g7hSkqSyotJ0AOjDzk7KqFXTngo7slTdcawPVl54VQOTX7T4dtE/bt4wEKhp0aBGkcyPRK6vfu48gwf9DRgjeNSa/00hzTAwTDeX1LPpXOWWY+Apy1xeNLLMZMQhv26bDpz8hNnAOFx843cmmJtCaxNoe3i/nBBTARf5/rmHgzhpZ/SDX+6KXmcnK2z9HeScTI3wWBnSrfJKYpCTNAASoOy/7DpQan7lAFKjk2lnj2DjgSL7YacrWFXY+fXGNpgYNbbYRMAnPvuyOJ87MKmkgf2CeFN6hm0HcrI/E4lu6LIsW97yQpHSzRgWRtdM3cFrbWCKn27sqJ9LrgiIk4xYLNED4V/WbeSN06yxYBk7+R2SrXB0VW4lGVr+76K64409eXLoFIJQVIF22KITphLcDs9Z4xdANP3jD9QjcP0+ZQUBup0NootC896ERXcOgEU4E0aOCUP0uM5mAJkA+B+98JFVtBNQ6HViOzX0a9oluGcR7KI9Wsa8Xe4z63+vJFwpzU37y0277DjHWjUKMHQ65z2L5p30IsI+zoEQmbZNw9m7hPDXrU7hb0MHTyeHdU1P7BJH5VP+IYcsfzI2bFdDbUOcETERzUrcAMysmn89ijyIyqOWOWLiCXtaenQyjE8EmBBsbEegwk1xyB/uXghBq6MiKtGhDJUWxY8hq11hkMJ9eHwXAc9DVtaeBoBYQ37ZjQsF+negevGjNK+kp17aimqGo6c6lEj+ncc1MkDwiy5rJHyiRVSiHSFfxBcPW0lJE/s+G5OHZC6ryPTg2oG7FTIjVJsrjJxry4a46sbsx8Vdn5LCpgtXnrUp3cgHD3b7wP/q6zg1tePnYf/W4IumJeiE1gtDXepWlqspf2+KDi0CzMgB7aGkZSylM8FEVZOOfPLXab7qezhNybYc+ekG1+UjESl1RpplRc1VpwTAH7Bn6CZBUH01SQC1yu0tma/OX1cDUKfxETwsnjoacSzGuEZDDZars2OUd51oxEp6q05B/Ks0Cvz+hX86PTFIEsIvdnc+6KQuiNk5hwI6odsJ+S4vNYMy4rL95LQpFaNzHo8TyZ+Wj3MuW7Yg9Y6PXZHUaSOgC/xyRlCwUL8a49eKwT8muoW5+8IwmbHlm/rfTXPf4gZkXjSiQKCXRi1DBRGOuO19cmTSwbXs7Cv+V+7kxpmPbTwSa+Pp/gXEcdwzmK9icCszRia+IJta5MZZK0HkvLX6NNqSzZjGq9a9FbROF2lKualFkvqGkC123H5h4TT8Gs5LhgobXVF7US0SJF9DHn/CRO6GE1S90fdjHzfl1CiwrwIsjJNq68xyodXyqhYY1ci8d5yFzHxWU02ZYAr3n4RmIFa/QQtb8nZrKp3PAxHk4XLDtSfUc/aeSeNrdIjAZO8ohZ11lCEO97qlHOw1KCCojGpfMmyxS07ieY7m1zfvWfBcvPKNY6FPi9thl9M05dYHYpawab6vt57jLkd/7lvca/LjJ81LWmneuzrTEfLrlP+4oK1tUgxSfAr7SwrebPRaE92+HKztt9n8HqSjeo4HZKJB/B62wSG4G8OZE0c4rJsjWLPXsD6SkqCejdTAczcTl98uDF0U95DoiArqkYri3LwFud3iWi9GwT1E+nHPU5FDZm9j+2F5HR39N2QbbsQc9MPyaCnNfFWHyQggorOeiAAQxLcoKwkT+JYs1IUxb5VKLHWBXDa6ToxQEGrqYoH4DnP1eBc4SD86n5JYGDqoyk7GR81aabAPCj/zZubtX8CuoHg7EiZcKxW5MU0kgxpeekPRFjRbUXfJVjjjpeDMeQudulAViz81yH1cWfUY1J6pKmveMNz8kcAXUexNTAuexbu77CRxbVzA6n9agrKxD+tBV7OrPMKZysltgrkHVdVm5JxWTqZsesWOnzI+2T3mmTixrAw+t+VN4q39sQFlwhkqxOF+aiUS/F5TcCoDzon2uVb8MlXd2lJaXjzE04i5qzYpBNyLBeZVzame0OLjBYNWv/EaXToP3R1ViWNPoDMaJTSbQyZBtviU0tPkbgYNBOwcVLLgBmEN1XAI5H0A==,iv:iuv9q4fB34G7cOF8GZsUfGWmGtbekbXEFq+NlsuU1yI=,tag:aI956p+lQaOEPyryI3KTTA==,type:str]
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age:
+    - recipient: age12vs3x7x0ne8ghx4js9dwetn29vvtrrelvcgup2reqmdhdeqwd9hqht25ex
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRQzBQczVoUnBEQzJjaGtB
+        YVVIdnJEWHNhQVBoR3UxV1grdXVQRkovNHlJCjJkdWYzNTZacldnQVVqb0ZkR1VE
+        ZGEvMWxaMFpsZVh1V2szOElUcmc0MU0KLS0tIHRuWklMU1o4aGRjUEwvcFlmMHdX
+        c0s4MmIxT2FoUjUzaUR0VE1tdTIwbTAKJfkwu4gAjxXSHm83R97N/GtqT/hxNXj5
+        tARdYacc94cyHbElyVIaZIXnkrE5IxDJsI1Uzj8OvllSfrGa1FItmA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2023-02-17T07:52:13Z"
+  mac: ENC[AES256_GCM,data:afzL3WF5wX7nC8N5icWccVBqZufCVWGTBQtXsgmFfR+Q/KPEdVOuuCnVTJN3v2TJBUd+ho4O/RBqca0k4F530xRxMHkHaFsTqyWzZdKr1qDXtdDM26Kuc43xcjEnRqWNARvRHWb70LNrM+QdXvEIDVR96DMQOhe4+pHs6rYtKec=,iv:FCNXVhYHEDV7eQ4VdCpofTi232CfgtiIRVGsVl9n1Tw=,tag:4KhVQ2Q9kPASpikWbdRqkg==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.7.3
+
+---
+
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: create-capg-cluster
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: create-capg-cluster
+  annotations:
+    tekton.dev/tags: capg, capi, create-cluster, gcp
+    tekton.dev/displayName: "Create CAPG cluster"
+spec:
+  description: Creates a new CAPG workload cluster
+
+  params:
+    - name: GIT_REVISION
+      type: string
+      description: The git commit SHA
+    - name: REPO_NAME
+      type: string
+      description: The name of the repo triggering this pipeline
+    - name: REPO_ORG
+      type: string
+      description: The owner of the repo triggering this pipeline
+
+  workspaces:
+    - name: shared
+
+  tasks:
+    - name: create-github-check
+      taskRef:
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: github-checks
+        - name: namespace
+          value: tekton-pipelines
+      params:
+        - name: SHA
+          value: $(params.GIT_REVISION)
+        - name: REPO
+          value: "$(params.REPO_ORG)/$(params.REPO_NAME)"
+        - name: STATUS
+          value: "in_progress"
+        - name: CHECK_NAME
+          value: "Create cluster"
+
+    - name: calculate-versions
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: capi-cluster-calculate-versions
+          - name: namespace
+            value: tekton-pipelines
+      params:
+        - name: REPO
+          value: "$(params.REPO_ORG)/$(params.REPO_NAME)"
+        - name: SHA
+          value: $(params.GIT_REVISION)
+        - name: PROVIDER
+          value: "CAPG"
+
+    - name: generate-cluster-name
+      taskRef:
+        resolver: cluster
+        params:
+          - name: kind
+            value: task
+          - name: name
+            value: generate-random-name
+          - name: namespace
+            value: tekton-pipelines
+
+    - name: build-values
+      runAfter:
+        - calculate-versions
+        - generate-cluster-name
+      workspaces:
+        - name: values
+          workspace: shared
+          subPath: values
+      params:
+        - name: CLUSTER_NAME
+          value: $(tasks.generate-cluster-name.results.value)
+      taskSpec:
+        params:
+          - name: CLUSTER_NAME
+            type: string
+        workspaces:
+          - name: values
+            description: |
+              A directory containing two values files: cluster-values.yaml and default-apps-values.yaml
+        steps:
+        - name: build-values
+          image: quay.io/giantswarm/tinkerers-ci:latest
+          env:
+            - name: CLUSTER_NAME
+              value: "$(params.CLUSTER_NAME)"
+          script: |
+            #!/usr/bin/env bash
+
+            CLUSTER_EXTERNAL_IP=$(curl https://api.ipify.org)
+
+            echo "
+            clusterName: ${CLUSTER_NAME}
+            clusterDescription: e2e test
+            organization: giantswarm
+            controlPlane:
+              apiAllowlistSubnets: "${CLUSTER_EXTERNAL_IP}/32"
+              containerdVolume: {}
+              etcdVolume: {}
+              kubeletVolume: {}
+              replicas: 3
+              rootVolume: {}
+              serviceAccount:
+                email: default
+                scopes:
+                - https://www.googleapis.com/auth/compute
+            gcp:
+              failureDomains:
+              - europe-west6-a
+              project: giantswarm-352614
+              region: europe-west6
+            machineDeployments:
+            - containerdVolume: {}
+              failureDomain: europe-west6-a
+              instanceType: n1-standard-4
+              kubeletVolume: {}
+              name: worker0
+              replicas: 3
+              rootVolume:
+                sizeGB: 100
+              serviceAccount:
+                email: default
+                scopes:
+                - https://www.googleapis.com/auth/compute
+            " > "$(workspaces.values.path)/cluster-values.yaml"
+
+            echo "
+            clusterName: ${CLUSTER_NAME}
+            organization: giantswarm
+            " > "$(workspaces.values.path)/default-apps-values.yaml"
+
+    - name: create-cluster
+      runAfter:
+        - build-values
+      taskRef:
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: capi-create-cluster
+        - name: namespace
+          value: tekton-pipelines
+      params:
+        - name: CLUSTER_APP_NAME
+          value: "$(tasks.calculate-versions.results.cluster-app-chart-name)"
+        - name: CLUSTER_APP_VERSION
+          value: "$(tasks.calculate-versions.results.cluster-app-chart-version)"
+        - name: CLUSTER_APP_CATALOG
+          value: "$(tasks.calculate-versions.results.cluster-app-catalog)"
+        - name: DEFAULT_APPS_APP_NAME
+          value: "$(tasks.calculate-versions.results.default-apps-chart-name)"
+        - name: DEFAULT_APPS_APP_VERSION
+          value: "$(tasks.calculate-versions.results.default-apps-chart-version)"
+        - name: DEFAULT_APPS_APP_CATALOG
+          value: "$(tasks.calculate-versions.results.default-apps-catalog)"
+        - name: MC_KUBECONFIG_SECRET
+          value: "mc-kubeconfig-gohan"
+        - name: CLUSTER_NAME
+          value: $(tasks.generate-cluster-name.results.value)
+      workspaces:
+        - name: values
+          workspace: shared
+          subPath: values
+        - name: kubeconfig
+          workspace: shared
+          subPath: kubeconfig
+
+    - name: wait-for-ready
+      runAfter:
+        - create-cluster
+      timeout: 1h0m0s
+      taskRef:
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: cluster-wait-for-ready
+        - name: namespace
+          value: tekton-pipelines
+      params:
+        - name: PROVIDER
+          value: "CAPG"
+      workspaces:
+        - name: kubeconfig
+          workspace: shared
+          subPath: kubeconfig
+
+  finally:
+    - name: cleanup-cluster
+      taskRef:
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: capi-delete-cluster
+        - name: namespace
+          value: tekton-pipelines
+      params:
+        - name: CLUSTER_NAME
+          value: "$(tasks.create-cluster.results.cluster-name)"
+        - name: MC_KUBECONFIG_SECRET
+          value: "mc-kubeconfig-gohan"
+
+    - name: complete-github-check
+      taskRef:
+        resolver: cluster
+        params:
+        - name: kind
+          value: task
+        - name: name
+          value: github-checks
+        - name: namespace
+          value: tekton-pipelines
+      params:
+        - name: SHA
+          value: $(params.GIT_REVISION)
+        - name: REPO
+          value: "$(params.REPO_ORG)/$(params.REPO_NAME)"
+        - name: STATUS
+          value: "completed"
+        - name: CHECK_NAME
+          value: "Create cluster"
+        - name: CONCLUSION
+          value: "$(tasks.status)"
+
+  results:
+    - name: cluster-app-chart-name
+      description: The name of the cluster app used to build the WC
+      value: $(tasks.calculate-versions.results.cluster-app-chart-name)
+    - name: cluster-app-chart-version
+      description: The version of the cluster app used to build the WC
+      value: $(tasks.calculate-versions.results.cluster-app-chart-version)
+    - name: default-apps-chart-name
+      description: The name of the default-apps app used to build the WC
+      value: $(tasks.calculate-versions.results.default-apps-chart-name)
+    - name: default-apps-chart-version
+      description: The version of the default-apps app used to build the WC
+      value: $(tasks.calculate-versions.results.default-apps-chart-version)
+    - name: cluster-name
+      description: The name of the workload cluster
+      value: $(tasks.create-cluster.results.cluster-name)
+    - name: cluster-namespace
+      description: The namespace of the workload cluster
+      value: $(tasks.create-cluster.results.cluster-namespace)
+
+---

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -63,7 +63,7 @@ spec:
         CLUSTER_APP=""
         DEFAULT_APPS_APP=""
 
-        case "${PROVIDER}" in
+        case "${PROVIDER,,}" in
         "capa" | "aws")
             CLUSTER_APP="cluster-aws"
             DEFAULT_APPS_APP="default-apps-aws"

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: capi-cluster-calculate-versions

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -126,9 +126,17 @@ spec:
         # Trim org from repo name
         REPO=${REPO#"giantswarm/"}
 
-        CLUSTER_APP_VERSION=""
+        CLUSTER_APP_VERSION="$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          /repos/giantswarm/${CLUSTER_APP}/tags \
+          | jq -r '.[0].name | ltrimstr("v")'
+        )"
         CLUSTER_APP_CATALOG="cluster"
-        DEFAULT_APPS_VERSION=""
+        DEFAULT_APPS_VERSION="$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          /repos/giantswarm/${DEFAULT_APPS_APP}/tags \
+          | jq -r '.[0].name | ltrimstr("v")'
+        )"
         DEFAULT_APPS_CATALOG="cluster"
 
         if [[ "${REPO}" == "${CLUSTER_APP}" ]]; then

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -121,7 +121,7 @@ spec:
           /repos/${REPO}/tags \
           | jq -r '.[0].name'
         )
-        CHART_VERSION="${LATEST_TAG}-${SHA}""
+        CHART_VERSION="${LATEST_TAG}-${SHA}"
 
         # Trim org from repo name
         REPO=${REPO#"giantswarm/"}

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -1,0 +1,145 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: capi-cluster-calculate-versions
+  labels:
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: capi, workload-cluster
+    tekton.dev/displayName: "CAPI cluster - calculate versions"
+spec:
+  description: "Calculates the versions of cluster related apps to use"
+
+  params:
+  # Required
+  - name: REPO
+    type: string
+    description: The repository that has triggered the pipeline in the format `organisation/repo-name`.
+
+  - name: SHA
+    type: string
+    description: The commit SHA that has triggered the pipeline
+
+  - name: PROVIDER
+    type: string
+    description: The provider we are building a cluster for. (E.g. capa, capg)
+
+  # Optional
+  - name: IMAGE
+    type: string
+    default: "quay.io/giantswarm/tinkerers-ci:latest"
+
+  - name: GITHUB_TOKEN_SECRET
+    type: string
+    description: The name of the secret containing the GitHub authentication credentials.
+    default: tinkerers-ci-github-token
+
+  results:
+  - name: cluster-app-chart-name
+    description: The name of the cluster app to use.
+  - name: cluster-app-chart-version
+    description: Version to use when installing the cluster app.
+  - name: cluster-app-catalog
+    description: Catalog to use when installing the cluster app.
+
+  - name: default-apps-chart-name
+    description: The name of the default-apps app to use.
+  - name: default-apps-chart-version
+    description: Version to use when installing default-apps app.
+  - name: default-apps-catalog
+    description: Catalog to use when installing the default-apps app.
+
+  steps:
+    - name: map-provider-to-charts
+      image: $(params.IMAGE)
+      env:
+        - name: PROVIDER
+          value: $(params.PROVIDER)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        # Work out app names from provider
+        CLUSTER_APP=""
+        DEFAULT_APPS_APP=""
+
+        case "${PROVIDER}" in
+        "capa" | "aws")
+            CLUSTER_APP="cluster-aws"
+            DEFAULT_APPS_APP="default-apps-aws"
+            ;;
+        "capg" | "gcp")
+            CLUSTER_APP="cluster-gcp"
+            DEFAULT_APPS_APP="default-apps-gcp"
+            ;;
+        "capz" | "azure")
+            CLUSTER_APP="cluster-azure"
+            DEFAULT_APPS_APP="default-apps-azure"
+            ;;
+        "capo" | "openstack")
+            CLUSTER_APP="cluster-openstack"
+            DEFAULT_APPS_APP="default-apps-openstack"
+            ;;
+        "capv" | "vsphere")
+            CLUSTER_APP="cluster-vsphere"
+            DEFAULT_APPS_APP="default-apps-vsphere"
+            ;;
+        "capvcd" | "cloud-director" | "clouddirector")
+            CLUSTER_APP="cluster-cloud-director"
+            DEFAULT_APPS_APP="default-apps-cloud-director"
+            ;;
+        *)
+            echo "Unknown provider. Unable to match to cluster app."
+            exit 1
+            ;;
+        esac
+
+        echo -n ${CLUSTER_APP} > $(results.cluster-app-chart-name.path)
+        echo -n ${DEFAULT_APPS_APP} > $(results.default-apps-chart-name.path)
+
+    - name: calculate-chart-versions
+      image: $(params.IMAGE)
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.GITHUB_TOKEN_SECRET)
+              key: GITHUB_TOKEN
+        - name: REPO
+          value: $(params.REPO)
+        - name: SHA
+          value: $(params.SHA)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        CLUSTER_APP=$(cat $(results.cluster-app-chart-name.path))
+        DEFAULT_APPS_APP=$(cat $(results.default-apps-chart-name.path))
+
+        LATEST_TAG=$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          /repos/${REPO}/tags \
+          | jq -r '.[0].name'
+        )
+        CHART_VERSION="${LATEST_TAG}-${SHA}""
+
+        # Trim org from repo name
+        REPO=${REPO#"giantswarm/"}
+
+        CLUSTER_APP_VERSION=""
+        CLUSTER_APP_CATALOG="cluster"
+        DEFAULT_APPS_VERSION=""
+        DEFAULT_APPS_CATALOG="cluster"
+
+        if [[ "${REPO}" == "${CLUSTER_APP}" ]]; then
+          CLUSTER_APP_CATALOG="cluster-test"
+          CLUSTER_APP_VERSION=${CHART_VERSION}
+        else
+          DEFAULT_APPS_CATALOG="cluster-test"
+          DEFAULT_APPS_VERSION=${CHART_VERSION}
+        fi
+
+        echo -n ${CLUSTER_APP_VERSION} > $(results.cluster-app-chart-version.path)
+        echo -n ${CLUSTER_APP_CATALOG} > $(results.cluster-app-catalog.path)
+        echo -n ${DEFAULT_APPS_VERSION} > $(results.default-apps-chart-version.path)
+        echo -n ${DEFAULT_APPS_CATALOG} > $(results.default-apps-catalog.path)

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -134,7 +134,7 @@ spec:
         if [[ "${REPO}" == "${CLUSTER_APP}" ]]; then
           CLUSTER_APP_CATALOG="cluster-test"
           CLUSTER_APP_VERSION=${CHART_VERSION}
-        else
+        elif [[ "${REPO}" == "${DEFAULT_APPS_APP}" ]]
           DEFAULT_APPS_CATALOG="cluster-test"
           DEFAULT_APPS_VERSION=${CHART_VERSION}
         fi

--- a/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
+++ b/tekton-resources/tasks/capi-cluster-calculate-versions.yaml
@@ -142,7 +142,7 @@ spec:
         if [[ "${REPO}" == "${CLUSTER_APP}" ]]; then
           CLUSTER_APP_CATALOG="cluster-test"
           CLUSTER_APP_VERSION=${CHART_VERSION}
-        elif [[ "${REPO}" == "${DEFAULT_APPS_APP}" ]]
+        elif [[ "${REPO}" == "${DEFAULT_APPS_APP}" ]]; then
           DEFAULT_APPS_CATALOG="cluster-test"
           DEFAULT_APPS_VERSION=${CHART_VERSION}
         fi

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -29,7 +29,7 @@ spec:
     description: The version of the default-apps app to use
 
   - name: MC_KUBECONFIG_SECRET
-    type: sting
+    type: string
     description: The name of the Kubernetes secret containing the MCs kubeconfig file
 
   # Optional

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -52,11 +52,6 @@ spec:
     type: string
     default: "quay.io/giantswarm/tinkerers-ci:latest"
 
-  - name: GITHUB_TOKEN_SECRET
-    type: string
-    description: The name of the secret containing the GitHub authentication credentials.
-    default: tinkerers-ci-github-token
-
   volumes:
     - name: app-manifests
       emptyDir: {}

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: capi-create-cluster

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -43,6 +43,11 @@ spec:
     description: The catalog of the default-apps app
     default: cluster
 
+  - name: CLUSTER_NAME
+    type: string
+    description: The name of the cluster to use. If not provided one will be generated.
+    default: ""
+
   - name: CLUSTER_NAMESPACE
     type: string
     description: The namespace on the MC that the cluster resources will be deployed to
@@ -91,6 +96,8 @@ spec:
           value: $(params.DEFAULT_APPS_APP_VERSION)
         - name: DEFAULT_APPS_APP_CATALOG
           value: $(params.DEFAULT_APPS_APP_CATALOG)
+        - name: CLUSTER_NAME
+          value: $(params.CLUSTER_NAME)
         - name: CLUSTER_NAMESPACE
           value: $(params.CLUSTER_NAMESPACE)
       volumeMounts:
@@ -100,7 +107,7 @@ spec:
         #!/usr/bin/env bash
         set -e
 
-        CLUSTER_NAME="t$(date +%s | cut -c7-10)"
+        CLUSTER_NAME=${CLUSTER_NAME:="t$(date +%s | cut -c7-10)"}
 
         kubectl gs template app \
           --app-name "${CLUSTER_NAME}" \

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -136,7 +136,7 @@ spec:
         echo -n "${CLUSTER_NAME}" > $(results.cluster-name.path)
         echo -n "${CLUSTER_NAMESPACE}" > $(results.cluster-namespace.path)
 
-    - name: template-apps
+    - name: apply-cluster-manifests
       image: $(params.IMAGE)
       env:
         - name: CLUSTER_NAMESPACE

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -1,0 +1,160 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: capi-create-cluster
+  labels:
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: capi, workload-cluster
+    tekton.dev/displayName: "CAPI - Create cluster"
+spec:
+  description: Generates the cluster and default-apps manifests based on values provided and applies them to the MC
+
+  params:
+  # Required
+  - name: CLUSTER_APP_NAME
+    type: string
+    description: The name of the cluster app to use
+
+  - name: CLUSTER_APP_VERSION
+    type: string
+    description: The version of the cluster app to use
+
+  - name: DEFAULT_APPS_APP_NAME
+    type: string
+    description: The name of the default-apps app to use
+
+  - name: DEFAULT_APPS_APP_VERSION
+    type: string
+    description: The version of the default-apps app to use
+
+  - name: MC_KUBECONFIG_SECRET
+    type: sting
+    description: The name of the Kubernetes secret containing the MCs kubeconfig file
+
+  # Optional
+  - name: CLUSTER_APP_CATALOG
+    type: string
+    description: The catalog of the cluster app
+    default: cluster
+
+  - name: DEFAULT_APPS_APP_CATALOG
+    type: string
+    description: The catalog of the default-apps app
+    default: cluster
+
+  - name: CLUSTER_NAMESPACE
+    type: string
+    description: The namespace on the MC that the cluster resources will be deployed to
+    default: "org-giantswarm"
+
+  - name: IMAGE
+    type: string
+    default: "quay.io/giantswarm/tinkerers-ci:latest"
+
+  - name: GITHUB_TOKEN_SECRET
+    type: string
+    description: The name of the secret containing the GitHub authentication credentials.
+    default: tinkerers-ci-github-token
+
+  volumes:
+    - name: app-manifests
+      emptyDir: {}
+    - name: kubeconfig
+      secret:
+        secretName: $(params.MC_KUBECONFIG_SECRET)
+
+  workspaces:
+    - name: values
+      description: |
+        A directory containing two values files: cluster-values.yaml and default-apps-values.yaml
+      readOnly: true
+
+    - name: kubeconfig
+      description: |
+        The directory where the workload cluster kubeconfig will be stored
+
+  results:
+    - name: custer-name
+      description: The unique name of the cluster
+    - name: custer-namespace
+      description: The namespace the cluster is deployed into
+
+  steps:
+    - name: template-apps
+      image: $(params.IMAGE)
+      env:
+        - name: CLUSTER_APP_NAME
+          value: $(params.CLUSTER_APP_NAME)
+        - name: CLUSTER_APP_VERSION
+          value: $(params.CLUSTER_APP_VERSION)
+        - name: CLUSTER_APP_CATALOG
+          value: $(params.CLUSTER_APP_CATALOG)
+        - name: DEFAULT_APPS_APP_NAME
+          value: $(params.DEFAULT_APPS_APP_NAME)
+        - name: DEFAULT_APPS_APP_VERSION
+          value: $(params.DEFAULT_APPS_APP_VERSION)
+        - name: DEFAULT_APPS_APP_CATALOG
+          value: $(params.DEFAULT_APPS_APP_CATALOG)
+        - name: CLUSTER_NAMESPACE
+          value: $(params.CLUSTER_NAMESPACE)
+      volumeMounts:
+        - name: app-manifests
+          mountPath: /mnt/app-manifests
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        CLUSTER_NAME="t$(date +%s | cut -c7-10)"
+
+        kubectl gs template app \
+          --app-name "${CLUSTER_NAME}" \
+          --name "${CLUSTER_APP_NAME}" \
+          --version "${CLUSTER_APP_VERSION}" \
+          --catalog "${CLUSTER_APP_CATALOG}" \
+          --target-namespace "${CLUSTER_NAMESPACE}" \
+          --in-cluster \
+          --user-configmap "$(workspaces.values.path)/cluster-values.yaml" \
+          > "/mnt/app-manifests/cluster.yaml"
+
+        # Fix the name of the ConfigMap
+        sed -i 's/-userconfig/-user-values/g' "/mnt/app-manifests/cluster.yaml"
+
+        kubectl gs template app \
+            --app-name "${CLUSTER_NAME}-default-apps" \
+            --name "${DEFAULT_APPS_APP_NAME}" \
+            --version "v${DEFAULT_APPS_APP_VERSION}" \
+            --catalog "${DEFAULT_APPS_APP_CATALOG}" \
+            --target-namespace "${CLUSTER_NAMESPACE}" \
+            --in-cluster \
+            --user-configmap "$(workspaces.values.path)/default-apps-values.yaml" \
+          > "/mnt/app-manifests/default-apps.yaml"
+
+        # Fix the name of the ConfigMap
+        sed -i 's/-userconfig/-user-values/g' "/mnt/app-manifests/default-apps.yaml"
+
+        echo -n "${CLUSTER_NAME}" > $(results.cluster-name.path)
+        echo -n "${CLUSTER_NAMESPACE}" > $(results.cluster-namespace.path)
+
+    - name: template-apps
+      image: $(params.IMAGE)
+      env:
+        - name: CLUSTER_NAMESPACE
+          value: $(params.CLUSTER_NAMESPACE)
+      volumeMounts:
+        - name: app-manifests
+          mountPath: /mnt/app-manifests
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig/kubeconfig
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        export KUBECONFIG=/etc/kubeconfig/kubeconfig
+
+        kubectl apply -f /mnt/app-manifests/*.yaml
+
+        CLUSTER_NAME=$(cat $(results.cluster-name.path))
+
+        while ! kubectl get secrets -n ${CLUSTER_NAMESPACE} ${CLUSTER_NAME}-kubeconfig; do echo "waiting for kubeconfig"; sleep 10; done
+        kubectl get secrets -n ${CLUSTER_NAMESPACE} ${CLUSTER_NAME}-kubeconfig -o jsonpath='{.data.value}' | base64 -d > $(workspaces.kubeconfig.path)/kubeconfig

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -121,6 +121,8 @@ spec:
 
         # Fix the name of the ConfigMap
         sed -i 's/-userconfig/-user-values/g' "/mnt/app-manifests/cluster.yaml"
+        # Add missing labels to ConfigMap
+        yq -i 'select(.kind == "ConfigMap").metadata.labels."giantswarm.io/cluster" = "'${CLUSTER_NAME}'"' "/mnt/app-manifests/cluster.yaml"
 
         kubectl gs template app \
             --app-name "${CLUSTER_NAME}-default-apps" \
@@ -129,11 +131,17 @@ spec:
             --catalog "${DEFAULT_APPS_APP_CATALOG}" \
             --target-namespace "${CLUSTER_NAMESPACE}" \
             --in-cluster \
+            --cluster-name "${CLUSTER_NAME}" \
             --user-configmap "$(workspaces.values.path)/default-apps-values.yaml" \
           > "/mnt/app-manifests/default-apps.yaml"
 
         # Fix the name of the ConfigMap
         sed -i 's/-userconfig/-user-values/g' "/mnt/app-manifests/default-apps.yaml"
+        # Add missing labels to App
+        yq -i 'select(.kind == "App").metadata.labels."giantswarm.io/managed-by" = "cluster"' "/mnt/app-manifests/default-apps.yaml"
+        # Add cluster values as config
+        yq -i 'select(.kind == "App").spec.config.configMap.name = "'${CLUSTER_NAME}'-cluster-values"' "/mnt/app-manifests/default-apps.yaml"
+        yq -i 'select(.kind == "App").spec.config.configMap.namespace = "'${CLUSTER_NAMESPACE}'"' "/mnt/app-manifests/default-apps.yaml"
 
         echo -n "${CLUSTER_NAME}" > $(results.cluster-name.path)
         echo -n "${CLUSTER_NAMESPACE}" > $(results.cluster-namespace.path)

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -75,9 +75,9 @@ spec:
         The directory where the workload cluster kubeconfig will be stored
 
   results:
-    - name: custer-name
+    - name: cluster-name
       description: The unique name of the cluster
-    - name: custer-namespace
+    - name: cluster-namespace
       description: The namespace the cluster is deployed into
 
   steps:

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -147,14 +147,14 @@ spec:
         - name: app-manifests
           mountPath: /mnt/app-manifests
         - name: kubeconfig
-          mountPath: /etc/kubeconfig/kubeconfig
+          mountPath: /etc/kubeconfig
       script: |
         #!/usr/bin/env bash
         set -e
 
         export KUBECONFIG=/etc/kubeconfig/kubeconfig
 
-        kubectl apply -f /mnt/app-manifests/*.yaml
+        kubectl apply -f "/mnt/app-manifests/*.yaml"
 
         CLUSTER_NAME=$(cat $(results.cluster-name.path))
 

--- a/tekton-resources/tasks/capi-create-cluster.yaml
+++ b/tekton-resources/tasks/capi-create-cluster.yaml
@@ -154,6 +154,8 @@ spec:
 
         export KUBECONFIG=/etc/kubeconfig/kubeconfig
 
+        kubectl version
+
         kubectl apply -f "/mnt/app-manifests/*.yaml"
 
         CLUSTER_NAME=$(cat $(results.cluster-name.path))

--- a/tekton-resources/tasks/capi-delete-cluster.yaml
+++ b/tekton-resources/tasks/capi-delete-cluster.yaml
@@ -1,0 +1,55 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: capi-delete-cluster
+  labels:
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: capi, workload-cluster
+    tekton.dev/displayName: "CAPI - Delete cluster"
+spec:
+  description: Cleans up an existing CAPI cluster
+
+  params:
+  # Required
+  - name: CLUSTER_NAME
+    type: string
+    description: The unique name of the cluster within the MC
+
+  - name: MC_KUBECONFIG_SECRET
+    type: sting
+    description: The name of the Kubernetes secret containing the MCs kubeconfig file
+
+  # Optional
+  - name: CLUSTER_NAMESPACE
+    type: string
+    description: The namespace on the MC that the cluster resources will be deployed to
+    default: "org-giantswarm"
+
+  - name: IMAGE
+    type: string
+    default: "quay.io/giantswarm/tinkerers-ci:latest"
+
+  volumes:
+    - name: kubeconfig
+      secret:
+        secretName: $(params.MC_KUBECONFIG_SECRET)
+
+  steps:
+    - name: delete-cluster
+      image: $(params.IMAGE)
+      env:
+        - name: CLUSTER_NAMESPACE
+          value: $(params.CLUSTER_NAMESPACE)
+        - name: CLUSTER_NAME
+          value: $(params.CLUSTER_NAME)
+      volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig/kubeconfig
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        export KUBECONFIG=/etc/kubeconfig/kubeconfig
+
+        kubectl -n ${CLUSTER_NAMESPACE} delete app ${CLUSTER_NAME} ${CLUSTER_NAME}-default-apps --ignore-not-found

--- a/tekton-resources/tasks/capi-delete-cluster.yaml
+++ b/tekton-resources/tasks/capi-delete-cluster.yaml
@@ -17,7 +17,7 @@ spec:
     description: The unique name of the cluster within the MC
 
   - name: MC_KUBECONFIG_SECRET
-    type: sting
+    type: string
     description: The name of the Kubernetes secret containing the MCs kubeconfig file
 
   # Optional

--- a/tekton-resources/tasks/capi-delete-cluster.yaml
+++ b/tekton-resources/tasks/capi-delete-cluster.yaml
@@ -45,7 +45,7 @@ spec:
           value: $(params.CLUSTER_NAME)
       volumeMounts:
         - name: kubeconfig
-          mountPath: /etc/kubeconfig/kubeconfig
+          mountPath: /etc/kubeconfig
       script: |
         #!/usr/bin/env bash
         set -e

--- a/tekton-resources/tasks/cluster-wait-for-ready.yaml
+++ b/tekton-resources/tasks/cluster-wait-for-ready.yaml
@@ -1,0 +1,89 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: cluster-wait-for-ready
+  labels:
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: workload-cluster
+    tekton.dev/displayName: "Cluster - Wait for ready"
+spec:
+  description: Watches a cluster until a given number of nodes are running and ready
+
+  params:
+  # Required
+  - name: PROVIDER
+    type: string
+    description: |
+      The provider the cluster is running on. (E.g. aws, azure).
+      If CAPA, CAPG, etc. are provided these will be converted to the appropriate matching value.
+
+  # Optional
+  - name: NUM_OF_NODES
+    type: string
+    description: The number of nodes to wait for being ready
+    default: "4"
+
+  - name: IMAGE
+    type: string
+    default: "quay.io/giantswarm/standup:3.2.0"
+
+  - name: GITHUB_TOKEN_SECRET
+    type: string
+    description: The name of the secret containing the GitHub authentication credentials.
+    default: tinkerers-ci-github-token
+
+  workspaces:
+    - name: cluster
+      description: |
+        The directory where the cluster kubeconfig exists.
+        This requires a valid kubeconfig file named `kubeconfig`.
+      readOnly: true
+
+  steps:
+    - name: check-for-kubeconfig
+      image: bash:5
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        if [ ! -f "$(workspaces.cluster.path)/kubeconfig" ]; then
+          echo "Kubeconfig file is missing from the workspace"
+          exit 1
+        fi
+
+    - name: wait-for-ready
+      image: $(params.IMAGE)
+      env:
+        - name: PROVIDER
+          value: $(params.PROVIDER)
+        - name: NUM_OF_NODES
+          value: $(params.NUM_OF_NODES)
+      script: |
+        #! /bin/sh
+
+        case "${PROVIDER}" in
+        "capa" | "aws")
+            PROVIDER="aws"
+            ;;
+        "capg" | "gcp")
+            PROVIDER="gcp"
+            ;;
+        "capz" | "azure")
+            PROVIDER="azure"
+            ;;
+        "capo" | "openstack")
+            PROVIDER="openstack"
+            ;;
+        "capv" | "vsphere")
+            PROVIDER="vsphere"
+            ;;
+        "capvcd" | "cloud-director" | "clouddirector")
+            PROVIDER="cloud-director"
+            ;;
+        esac
+
+        standup wait \
+          --kubeconfig $(workspaces.cluster.path)/kubeconfig \
+          --provider $(cat $(results.provider.path)) \
+          --nodes ${NUM_OF_NODES}
+

--- a/tekton-resources/tasks/cluster-wait-for-ready.yaml
+++ b/tekton-resources/tasks/cluster-wait-for-ready.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: cluster-wait-for-ready

--- a/tekton-resources/tasks/cluster-wait-for-ready.yaml
+++ b/tekton-resources/tasks/cluster-wait-for-ready.yaml
@@ -29,7 +29,7 @@ spec:
     default: "quay.io/giantswarm/standup:3.2.0"
 
   workspaces:
-    - name: cluster
+    - name: kubeconfig
       description: |
         The directory where the cluster kubeconfig exists.
         This requires a valid kubeconfig file named `kubeconfig`.
@@ -56,7 +56,7 @@ spec:
       script: |
         #! /bin/sh
 
-        case "${PROVIDER}" in
+        case "${PROVIDER,,}" in
         "capa" | "aws")
             PROVIDER="aws"
             ;;

--- a/tekton-resources/tasks/cluster-wait-for-ready.yaml
+++ b/tekton-resources/tasks/cluster-wait-for-ready.yaml
@@ -35,27 +35,32 @@ spec:
         This requires a valid kubeconfig file named `kubeconfig`.
       readOnly: true
 
+  volumes:
+    - name: shared-dir
+      emptyDir: {}
+
   steps:
     - name: check-for-kubeconfig
       image: bash:5
       script: |
         #!/usr/bin/env bash
         set -e
-        if [ ! -f "$(workspaces.cluster.path)/kubeconfig" ]; then
+        if [ ! -f "$(workspaces.kubeconfig.path)/kubeconfig" ]; then
           echo "Kubeconfig file is missing from the workspace"
           exit 1
         fi
 
-    - name: wait-for-ready
-      image: $(params.IMAGE)
+    - name: map-provider-name
+      image: bash:5
       env:
         - name: PROVIDER
           value: $(params.PROVIDER)
-        - name: NUM_OF_NODES
-          value: $(params.NUM_OF_NODES)
+      volumeMounts:
+        - name: shared-dir
+          mountPath: /mnt/shared-dir
       script: |
-        #! /bin/sh
-
+        #!/usr/bin/env bash
+        set -e
         case "${PROVIDER,,}" in
         "capa" | "aws")
             PROVIDER="aws"
@@ -77,8 +82,23 @@ spec:
             ;;
         esac
 
+        echo -n ${PROVIDER} > /mnt/shared-dir/provider
+
+    - name: wait-for-ready
+      image: $(params.IMAGE)
+      env:
+        - name: NUM_OF_NODES
+          value: $(params.NUM_OF_NODES)
+      volumeMounts:
+        - name: shared-dir
+          mountPath: /mnt/shared-dir
+      script: |
+        #! /bin/sh
+
+        PROVIDER=$(cat /mnt/shared-dir/provider)
+
         standup wait \
-          --kubeconfig $(workspaces.cluster.path)/kubeconfig \
-          --provider $(cat $(results.provider.path)) \
+          --kubeconfig $(workspaces.kubeconfig.path)/kubeconfig \
+          --provider ${PROVIDER} \
           --nodes ${NUM_OF_NODES}
 

--- a/tekton-resources/tasks/cluster-wait-for-ready.yaml
+++ b/tekton-resources/tasks/cluster-wait-for-ready.yaml
@@ -28,11 +28,6 @@ spec:
     type: string
     default: "quay.io/giantswarm/standup:3.2.0"
 
-  - name: GITHUB_TOKEN_SECRET
-    type: string
-    description: The name of the secret containing the GitHub authentication credentials.
-    default: tinkerers-ci-github-token
-
   workspaces:
     - name: cluster
       description: |

--- a/tekton-resources/tasks/generate-random-name.yaml
+++ b/tekton-resources/tasks/generate-random-name.yaml
@@ -1,0 +1,43 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: generate-random-name
+  labels:
+    application.giantswarm.io/team: team-tinkerers
+  annotations:
+    tekton.dev/tags: random, name, id
+    tekton.dev/displayName: "Generate random name"
+spec:
+  description: Generates a random name
+
+  params:
+  # Required
+
+  # Optional
+  - name: PREFIX
+    type: string
+    description: A fixed prefix to use.
+    default: "t"
+
+  - name: LENGTH
+    type: string
+    description: The length of the random string not including the prefix
+    default: "9"
+
+  results:
+    - name: value
+      description: The generated random name
+
+  steps:
+    - name: generate
+      image: bash:5
+      env:
+        - name: PREFIX
+          value: $(params.PREFIX)
+        - name: LENGTH
+          value: $(params.LENGTH)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        NAME="${PREFIX}$(tr -dc 0-9 </dev/urandom | head -c ${LENGTH})"
+        echo -n "${NAME}" > $(results.value.path)


### PR DESCRIPTION
Includes:
* Task to calculate which cluster and default-apps chart / version to use.
* Cluster wait-for-cluster
* Task that takes in some values.yaml files and templates and applies the cluster and default-apps apps into the MC
* A task to clean up a WC
* A task to generate a random cluster name
* An example pipeline to test the creation of a CAPG workload cluster