### PR TITLE
Fix missing env from message param

### DIFF
--- a/tekton-resources/tasks/github-checks.yaml
+++ b/tekton-resources/tasks/github-checks.yaml
@@ -81,6 +81,8 @@ spec:
           value: $(params.CONCLUSION)
         - name: CHECK_NAME
           value: $(params.CHECK_NAME)
+        - name: MESSAGE
+          value: $(params.MESSAGE)
         - name: PIPELINE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Fix a bug where I missed adding the param as a env variable.